### PR TITLE
feat: Add extensions, theme model, and main page UI | update routing and onboarding

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET"/>
     <application
-        android:label="hyde_stylehub"
+        android:label="HyDE StyleHub"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/lib/core/extensions/date_format_extension.dart
+++ b/lib/core/extensions/date_format_extension.dart
@@ -1,0 +1,19 @@
+import 'package:intl/intl.dart';
+
+/// The extension for [DateTime] to format it in a specific way.
+///
+/// The format of the date is 'yyyy-MM-dd, h:mm a'.
+extension DateFormatExtension on DateTime {
+  /// The formatted date as a string.
+  String get formatted {
+    /// The formatter that formats the date in the specific way.
+    final DateFormat formatter = DateFormat(kDateFormat, kLocale);
+    return formatter.format(this);
+  }
+}
+
+/// The locale for the date formatter.
+const String kLocale = 'en';
+
+/// The format of the date for the date formatter.
+const String kDateFormat = 'yyyy-MM-dd, h:mm a';

--- a/lib/core/extensions/navigetion_extensions.dart
+++ b/lib/core/extensions/navigetion_extensions.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+
+extension NavigationExtension on BuildContext {
+  /// Push the route with the given [routeName] onto the navigator that most
+  /// tightly encloses the given [context].
+  //
+  /// The [arguments] parameter is passed to the pushed route.
+  ///
+  /// This method is just a wrapper around [Navigator.pushNamed] and is
+  /// provided to allow for more concise code when using this extension.
+  ///
+  /// The return value is the value that the popped route was removed with;
+  /// this route cannot interact with the route below itself, and the return
+  /// value is null unless the popped route was popped with [Navigator.pop]
+  /// (e.g. by pressing the back button on Android).
+
+  Future<dynamic> pushNamed(String routeName, {Object? arguments}) {
+    return Navigator.of(this).pushNamed(routeName, arguments: arguments);
+  }
+
+  /// Replace the current route of the navigator that most tightly encloses the
+  /// given [context] with the route named [routeName].
+  ///
+  /// The [arguments] parameter is passed to the pushed route.
+  ///
+  /// The return value is the value that the route that was removed was popped
+  /// with; this route cannot interact with the route below itself, and the
+  /// return value is null unless the removed route was popped with [Navigator.pop]
+  /// (e.g. by pressing the back button on Android).
+  Future<dynamic> pushReplaceNamed(String routeName, {Object? arguments}) {
+    return Navigator.of(this)
+        .pushReplacementNamed(routeName, arguments: arguments);
+  }
+
+  /// Push the route with the given [routeName] onto the navigator that most
+  /// tightly encloses the given [context].
+  ///
+  /// The [arguments] parameter is passed to the pushed route.
+  ///
+  /// The predicate is used to determine whether the route is removed.
+  /// The predicate is called with the pushed route as argument and must return
+  /// true if the route should be removed, false otherwise.
+  ///
+  /// The return value is the value that the route that was removed was popped
+  /// with; this route cannot interact with the route below itself, and the
+  /// return value is null unless the removed route was popped with [Navigator.pop]
+  /// (e.g. by pressing the back button on Android).
+  Future<dynamic> pushNamedAndRemoveUntil(String routeName,
+      {Object? arguments, required RoutePredicate predicate}) {
+    return Navigator.of(this)
+        .pushNamedAndRemoveUntil(routeName, predicate, arguments: arguments);
+  }
+
+  void pop() => Navigator.of(this).pop();
+}

--- a/lib/core/models/theme_model.dart
+++ b/lib/core/models/theme_model.dart
@@ -1,0 +1,27 @@
+class ThemeModel {
+  final String name;
+  final String link;
+  final String owner;
+  final String description;
+  final List<String> colorScheme;
+
+  ThemeModel({
+    required this.name,
+    required this.link,
+    required this.owner,
+    required this.description,
+    required this.colorScheme,
+  });
+
+
+  factory ThemeModel.fromJson(Map<String, dynamic> json) {
+    return ThemeModel(
+      name: json['name'],
+      link: json['link'],
+      owner: json['owner'],
+      description: json['description'],
+      colorScheme: List<String>.from(json['colorScheme']),
+    );
+  }
+  
+}

--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:hyde_stylehub/core/error/no_routes.dart';
 import 'package:hyde_stylehub/core/routing/routes.dart';
+import 'package:hyde_stylehub/features/pages/main/ui/page/main_page.dart';
 import 'package:hyde_stylehub/features/pages/onboarding_page/ui/page/onboarding_page.dart';
 
 class AppRouter {
@@ -27,9 +28,9 @@ class AppRouter {
       case Routes.onBoarding:
         page = const OnboardingPage();
         break;
-      // case Routes.mainPage:
-      //   page = const MainPage();
-      //   break;
+      case Routes.mainPage:
+        page = const MainPage();
+        break;
       default:
         page = const NoRoutes();
     }

--- a/lib/features/pages/main/ui/page/main_page.dart
+++ b/lib/features/pages/main/ui/page/main_page.dart
@@ -1,0 +1,139 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+import 'package:hyde_stylehub/core/models/theme_model.dart';
+
+class MainPage extends StatefulWidget {
+  const MainPage({super.key});
+
+  @override
+  State<MainPage> createState() => _MainPageState();
+}
+
+class _MainPageState extends State<MainPage> {
+  late Future<List<ThemeModel>> _themesFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _themesFuture = fetchThemes();
+  }
+
+  Future<List<ThemeModel>> fetchThemes() async {
+    final response = await http.get(Uri.parse(
+        'https://raw.githubusercontent.com/HyDE-Project/hyde-gallery/master/hyde-themes.json'));
+
+    if (response.statusCode == 200) {
+      final List<dynamic> data = json.decode(response.body);
+      return data.map((json) => ThemeModel.fromJson(json)).toList();
+    } else {
+      throw Exception('Failed to load themes');
+    }
+  }
+
+  Widget _buildThemeCard(ThemeModel theme) {
+    final imageUrlPng =
+        'https://raw.githubusercontent.com/HyDE-Project/hyde-gallery/master/${Uri.encodeComponent(theme.name)}/image.png';
+    final imageUrlJpg =
+        'https://raw.githubusercontent.com/HyDE-Project/hyde-gallery/master/${Uri.encodeComponent(theme.name)}/image.jpg';
+
+    return Card(
+      elevation: 4,
+      margin: const EdgeInsets.all(12),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Image with fallback
+          FutureBuilder(
+            future: http.get(Uri.parse(imageUrlPng)),
+            builder: (context, snapshot) {
+              if (snapshot.connectionState == ConnectionState.waiting) {
+                return const SizedBox(
+                  height: 200,
+                  child: Center(child: CircularProgressIndicator()),
+                );
+              } else if (snapshot.hasData && snapshot.data?.statusCode == 200) {
+                return Image.network(imageUrlPng, fit: BoxFit.cover, height: 200, width: double.infinity);
+              } else {
+                return Image.network(imageUrlJpg, fit: BoxFit.cover, height: 200, width: double.infinity);
+              }
+            },
+          ),
+          Padding(
+            padding: const EdgeInsets.all(12.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(theme.name,
+                    style:
+                        const TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+                const SizedBox(height: 8),
+                Text(theme.description),
+                const SizedBox(height: 8),
+                Wrap(
+                  spacing: 8,
+                  children: theme.colorScheme
+                      .map((color) => CircleAvatar(
+                            backgroundColor: Color(_hexToColor(color)),
+                            radius: 10,
+                          ))
+                      .toList(),
+                ),
+                const SizedBox(height: 8),
+                Row(
+                  children: [
+                    TextButton(
+                      onPressed: () => _launchURL(theme.link),
+                      child: const Text('View Theme'),
+                    ),
+                    TextButton(
+                      onPressed: () => _launchURL(theme.owner),
+                      child: const Text('Owner'),
+                    ),
+                  ],
+                )
+              ],
+            ),
+          )
+        ],
+      ),
+    );
+  }
+
+  int _hexToColor(String hex) {
+    final buffer = StringBuffer();
+    if (hex.length == 6 || hex.length == 7) buffer.write('ff');
+    buffer.write(hex.replaceFirst('#', ''));
+    return int.parse(buffer.toString(), radix: 16);
+  }
+
+  void _launchURL(String url) async {
+    // Use url_launcher
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('HyDE Themes Gallery')),
+      body: FutureBuilder<List<ThemeModel>>(
+        future: _themesFuture,
+        builder: (context, snapshot) {
+          if (snapshot.hasData) {
+            final themes = snapshot.data!;
+            return ListView.builder(
+              itemCount: themes.length,
+              itemBuilder: (context, index) {
+                return _buildThemeCard(themes[index]);
+              },
+            );
+          } else if (snapshot.hasError) {
+            return Center(child: Text('Error: ${snapshot.error}'));
+          }
+          return const Center(child: CircularProgressIndicator());
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/pages/onboarding_page/ui/page/onboarding_page.dart
+++ b/lib/features/pages/onboarding_page/ui/page/onboarding_page.dart
@@ -1,10 +1,36 @@
 import 'package:flutter/material.dart';
+import 'package:hyde_stylehub/core/routing/routes.dart';
 
 class OnboardingPage extends StatelessWidget {
   const OnboardingPage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Placeholder();
+    return Scaffold(
+      body: Padding(
+        padding: const EdgeInsets.all(24.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              'Welcome to HyDE Style Hub',
+
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'HyDE Style Hub is a theme gallery for Flutter apps. You can browse and download themes for your app here.',
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.of(context).pushNamed(Routes.mainPage);
+              },
+              child: const Text('Get Started'),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }
+

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -334,7 +334,7 @@ packages:
     source: hosted
     version: "0.15.5"
   http:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: http
       sha256: fe7ab022b76f3034adc518fb6ea04a82387620e19977665ea18d30a1cf43442f

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   path_provider: ^2.1.5
   lottie: ^3.3.1
   toastification: ^3.0.1
+  http: ^1.3.0
 
   # objectbox: ^4.1.0
   # objectbox_flutter_libs: ^4.1.0 


### PR DESCRIPTION

- Added `date_format_extension.dart` and `navigation_extensions.dart` to core extensions.
- Added `theme_model.dart` for theme handling.
- Implemented `main_page.dart` UI.
- Updated `app_router.dart` to include new routes.
- Improved onboarding UI in `onboarding_page.dart`.
- Updated dependencies in `pubspec.yaml` and `pubspec.lock`.